### PR TITLE
Fix `asuint` operator when applied to `int` values.

### DIFF
--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -3783,7 +3783,9 @@ static bool HandleIntrinsicCall(SourceLocation CallLoc, unsigned opcode,
   case hlsl::IntrinsicOp::IOP_asuint:
     assert(Args.size() == 1 && "else call should be invalid");
     if (ArgValues[0].isInt()) {
-      Result = ArgValues[0];
+      APSInt value = ArgValues[0].getInt();
+      value.setIsUnsigned(true);
+      Result = APValue(value);
     }
     else if (ArgValues[0].isFloat()) {
       const bool isUnsignedTrue = true;

--- a/tools/clang/test/DXC/asuint-constant-eval.hlsl
+++ b/tools/clang/test/DXC/asuint-constant-eval.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc /T ps_6_9 -fcgl %s | FileCheck %s
+
+// Compiling this HLSL would fail this assertion in IntExprEvaluator::Success:
+//
+//     assert(SI.isSigned() == E->getType()->isSignedIntegerOrEnumerationType() &&
+//            "Invalid evaluation result.");
+//     
+// Bug was fixed in HandleIntrinsicCall by updating the APSInt's signednes.
+
+// CHECK: %{{.*}} = call i32 @"dx.hl.op.rn.i32 (i32, i32)"(i32 {{.*}}, i32 1)
+
+void main()
+{
+    int i = asuint(int(1));
+}


### PR DESCRIPTION
Bother to mark the APSInt result as unsigned, to avoid tripping IntExprEvaluator::Success's assertion that SI.isSigned() matches E's type.
